### PR TITLE
Don't export BM_PIPE_* array values

### DIFF
--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -20,7 +20,7 @@ export BM_{{ key|upper }}="{{ print_value(conf) }}"
             {%- for name, val in conf.iteritems() %}
                 {%- if key == 'pipe' %}
                     {%- for subkey, subvalue in val.iteritems() %}
-export BM_PIPE_{{ subkey|upper }}[{{ name }}]="{{ print_value(subvalue) }}"
+BM_PIPE_{{ subkey|upper }}[{{ name }}]="{{ print_value(subvalue) }}"
                     {%- endfor %}
                 {%- elif key == 'commands' %}
 export BM_{{ name|upper }}_COMMAND="{{ print_value(val) }}"


### PR DESCRIPTION
Hello,

As _BM_PIPE\_*_ settings are array values, _export_ doesn't work.

_declare -a_ would work but we can also use implicit declarations if I'm not mistaken.

Cheers,