### PR TITLE
Misc fixes

### DIFF
--- a/backupmanager/config.sls
+++ b/backupmanager/config.sls
@@ -1,13 +1,11 @@
 {% from "backupmanager/map.jinja" import map with context %}
 
-{% set template_file = salt['pillar.get']('backupmanager:lookup:template_file', 'salt://backupmanager/files/backup-manager.conf') %}
-
-{{ map.get('conf-file') }}:
+{{ map.lookup.conf_file }}:
   file.managed:
-    - user:     {{ map.get('user', 'root') }}
-    - group:    {{ map.get('group', 'root') }}
-    - mode:     440
+    - user:     root
+    - group:    {{ map.repository.group }}
+    - mode:     640
     - template: jinja
-    - source:   {{ template_file }}
+    - source:   {{ map.lookup.conf_file_source }}
     - context:
         included: False

--- a/backupmanager/defaults.yaml
+++ b/backupmanager/defaults.yaml
@@ -1,132 +1,34 @@
-lookup:
-  template_file: salt://backupmanager/files/backup-manager-postgres.conf
-  cron_file : /etc/cron.daily/backup-manager
-temp_dir: /tmp
+backupmanager:
+  lookup:
+    pkg: backup-manager
+    bin: /usr/sbin/backupmanager
+    conf_file: /etc/backup-manager.conf
+    conf_file_source: salt://backupmanager/files/backup-manager.conf
+    cron_file : /etc/cron.daily/backup-manager
+    cron_file_source: salt://backupmanager/files/cron.sh
 
-repository:
-  root:   /var/archives
-  secure: true
-  user:   root
-  group:  root
-  chmod:  770
+  temp_dir: /tmp
 
-archive:
-  chmod:          660
-  ttl:            5
-  frequency:      daily
-  recursivepurge: false
-  purgedups:      true
-  prefix:         $hostname
-  strictpurge:    true
-  nice_level:     10
-  archive_method: tarball
+  repository:
+    root:   /var/archives
+    secure: true
+    user:   root
+    group:  root
+    chmod:  770
 
-tarball:
-  nameformat:     long
-  filetype:       tar.gz
-  over_ssh:       false
-  dumpsymlinks:   false
-  targets:
-    - /etc/
-    - /boot
-  blacklist:
-    - /dev/
-    - /sys
-    - proc
-    - /tmp
-  slicesize: 1000M
-  extra_options:
-  masterdatetype: weekly
-  masterdatevalue: 1
+  archive:
+    chmod:          660
+    ttl:            5
+    frequency:      daily
+    recursivepurge: false
+    purgedups:      true
+    prefix:         $HOSTNAME
+    strictpurge:    true
+    nice_level:     10
 
-mysql:
-  databases:    __ALL__
-  safedumps:    true
-  adminlogin:   root
-  adminpass:
-  host:         localhost
-  port:         3306
-  filetype:     bzip2
-  extra_options:
-  separately:   true
-  dbexclude:
+  logger: "true"
+  logger_level: warning
+  logger_facility: user
 
-pgsql:
-   databases:   __ALL__
-   adminlogin:  root
-   adminpass:
-   host:        localhost
-   port:        5432
-   filetype:    bzip2
-   extra_options:
-
-svn:
-  repositories:
-  compresswith: bzip2
-
-upload:
-  method:
-  hosts:
-  destination:
-  ssh:
-    user:
-    key:
-    hosts:
-    port:
-    destination:
-    purge:
-    ttl:
-    gpg_recipient:
-  ftp:
-    secure:     false
-    passive:    true
-    timeout:    120
-    test:       false
-    user:
-    password:
-    hosts:
-    purge:
-    ttl:
-    destination:
-  s3:
-    destination:
-    access_key:
-    secret_key:
-    purge:  false
-    ttl:
-  rsync:
-    directories:
-    destination:
-    hosts:
-    dumpsymlinks: false
-    blacklist:
-    extra_options:
-    bandwidth_limit:
-  burning:
-    method:     none
-    chkmd5:     false
-    device:     /dev/cdrom
-    devforced:
-    iso_flags:  -R -J
-    maxsize:    650
-
-pipe:
-  0:
-    command: ssh host -c \"mysqldump -ufoo -pbar base\"
-    name: base
-    filetype: sql
-    compress: gzip
-  1:
-    command: ssh host -c \"mysqldump -ufoo -pbar base\"
-    name: base
-    filetype: sql
-    compress: gzip
-
-logger:
-    active:     true
-    level:      warning
-    facility:   user
-
-commands:
-    pre_backup:
-    post_backup:
+  pre_backup_command:
+  post_backup_command:

--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -34,9 +34,6 @@ export BM_TARBALL_TARGETS
                     {%- if val is iterable and val is not string %}
                         {%- if val is mapping %}
                             {%- for subkey, subvalue in val.iteritems() %}
-                                {%- if key == 'upload' and name == 'ssh' and subkey == 'gpg_recipient' %}
-export BM_UPLOAD_SSHGPG_RECIPIENT="{{ print_value(subvalue) }}"
-                                {%- endif %}
                                 {%- if subvalue is iterable and subvalue is not string %}
 export BM_{{ key|upper }}_{{ name|upper }}_{{ subkey|upper }}="{{ subvalue|join(' ') }}"
                                 {%- else %}

--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -16,13 +16,29 @@
     {%- for key, conf in salt['pillar.get']('backupmanager').iteritems() if key != 'lookup' %}
         {%- if conf is string %}
 export BM_{{ key|upper }}="{{ print_value(conf) }}"
+
+        {%- elif key == 'pipe' %}
+declare -a BM_PIPE_COMMAND
+declare -a BM_PIPE_NAME
+declare -a BM_PIPE_FILETYPE
+declare -a BM_PIPE_COMPRESS
+
+            {% for pipeconf in conf %}
+                {%- set index = loop.index0 %}
+                {%- for subkey, subvalue in pipeconf.items() %}
+                }
+{{ ['BM', key, subkey]|join('_')|upper }}[{{ index }}]="{{ print_value(subvalue) }}"
+                {%- endfor %}
+            {%- endfor %}
+
+export BM_PIPE_COMMAND
+export BM_PIPE_NAME
+export BM_PIPE_FILETYPE
+export BM_PIPE_COMPRESS
+
         {%- else %}
             {%- for name, val in conf.iteritems() %}
-                {%- if key == 'pipe' %}
-                    {%- for subkey, subvalue in val.iteritems() %}
-export BM_PIPE_{{ subkey|upper }}[{{ name }}]="{{ print_value(subvalue) }}"
-                    {%- endfor %}
-                {%- elif key == 'tarball' and name == 'targets' %}
+                {%- if key == 'tarball' and name == 'targets' %}
 declare -a BM_TARBALL_TARGETS
                     {%- for value in val %}
 BM_TARBALL_TARGETS[{{ loop.index0 }}]="{{ print_value(value) }}"

--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -12,7 +12,33 @@
     {%- endif -%}
 {% endmacro %}
 
+{%- set archive_method = [] %}
+{%- for key in salt['pillar.get']('backupmanager', {}).keys() %}
+    {%- if key in ('tarball', 'tarballinc', 'mysql', 'pgsql', 'pipe', 'svn') %}
+        {%- if key == "tarballinc" %}
+            {%- do archive_method.append("tarball-incremental") %}
+        {%- else %}
+            {%- do archive_method.append(key) %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+
+{%- set upload_method = [] %}
+{%- for key in salt['pillar.get']('backupmanager:upload', {}).keys() %}
+    {%- if key in ('scp', 'sshgpg', 'ftp', 'rsync', 's3') %}
+        {%- if key == "sshgpg" %}
+            {%- do upload_method.append("ssh-gpg") %}
+        {%- else %}
+            {%- do upload_method.append(key) %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+
 {%- if salt['pillar.get']('backupmanager') %}
+export BM_ARCHIVE_METHOD="{{ print_value(archive_method|join(" ")|default("none", true)) }}"
+
+export BM_UPLOAD_METHOD="{{ print_value(upload_method|join(" ")|default("none", true)) }}"
+
     {%- for key, conf in salt['pillar.get']('backupmanager').iteritems() if key != 'lookup' %}
         {%- if conf is string %}
 export BM_{{ key|upper }}="{{ print_value(conf) }}"

--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -22,8 +22,6 @@ export BM_{{ key|upper }}="{{ print_value(conf) }}"
                     {%- for subkey, subvalue in val.iteritems() %}
 export BM_PIPE_{{ subkey|upper }}[{{ name }}]="{{ print_value(subvalue) }}"
                     {%- endfor %}
-                {%- elif key == 'commands' %}
-export BM_{{ name|upper }}_COMMAND="{{ print_value(val) }}"
                 {%- elif key == 'tarball' and name == 'targets' %}
 declare -a BM_TARBALL_TARGETS
                     {%- for value in val %}

--- a/backupmanager/files/backup-manager.conf
+++ b/backupmanager/files/backup-manager.conf
@@ -1,6 +1,6 @@
 # This file is managed by SaltStack, DO NOT EDIT
 
-{% macro print_value(value) %}
+{%- macro print_value(value) %}
     {#- TODO: Handle list (|join, etc...) -#}
     {%- if value == None -%}
     {%- elif value == True -%}
@@ -10,7 +10,7 @@
     {%- else -%}
         {{ value }}
     {%- endif -%}
-{% endmacro %}
+{%- endmacro %}
 
 {%- set archive_method = [] %}
 {%- for key in salt['pillar.get']('backupmanager', {}).keys() %}

--- a/backupmanager/install.sls
+++ b/backupmanager/install.sls
@@ -1,26 +1,24 @@
 {% from "backupmanager/map.jinja" import map with context %}
 
-{% set cron_file = salt['pillar.get']('backupmanager:lookup:cron_file', 'salt://backupmanager/files/cron.sh') %}
-
 backupmanager:
   pkg.installed:
-    - name: {{ map.get('pkg') }}
+    - name: {{ map.lookup.pkg }}
 
 {{ map.repository.root }}:
   file.directory:
-    - user: {{ map.user }}
-    - group: {{ map.group }}
-    - mode: {{ map.chmod }}
+    - user: {{ map.repository.user }}
+    - group: {{ map.repository.group }}
+    - mode: {{ map.repository.chmod }}
     - makedirs: True
 
-{{ map.get('cron-daily-file') }}:
+{{ map.lookup.cron_file }}:
   file.managed:
     - user:     root
     - group:    root
     - mode:     751
     - template: jinja
-    - source:   {{ cron_file }}
+    - source:   {{ map.lookup.cron_file_source }}
     - defaults:
-          bin: {{ map.get('bin', '/usr/sbin/backup-manager') }}
+          bin: {{ map.lookup.bin }}
     - context:
         included: False

--- a/backupmanager/install.sls
+++ b/backupmanager/install.sls
@@ -6,6 +6,13 @@ backupmanager:
   pkg.installed:
     - name: {{ map.get('pkg') }}
 
+{{ map.repository.root }}:
+  file.directory:
+    - user: {{ map.user }}
+    - group: {{ map.group }}
+    - mode: {{ map.chmod }}
+    - makedirs: True
+
 {{ map.get('cron-daily-file') }}:
   file.managed:
     - user:     root

--- a/backupmanager/map.jinja
+++ b/backupmanager/map.jinja
@@ -1,19 +1,4 @@
-{% set map = salt['grains.filter_by']({
-    'Debian': {
-        'pkg': 'backup-manager',
-        'conf-file': '/etc/backup-manager.conf',
-        'bin': '/usr/sbin/backup-manager',
-        'cron-daily-file': '/etc/cron.daily/backup-manager',
-        'user': 'backup',
-        'group': 'backup',
-    },
-    'Ubuntu': {
-        'pkg': 'backup-manager',
-        'conf-file': '/etc/backup-manager.conf',
-        'bin': '/usr/sbin/backup-manager',
-        'cron-daily-file': '/etc/cron.daily/backup-manager',
-        'user': 'backup',
-        'group': 'backup',
-    },
+{% import_yaml "backupmanager/defaults.yaml" as defaults %}
 
-}, grain='os', merge=salt['pillar.get']('backupmanager:lookup')) %}
+{# merge the actual backupmanager pillar into defaults #}
+{% set map = salt['pillar.get']('backupmanager', default=defaults.backupmanager, merge=True) %}

--- a/pillar.example
+++ b/pillar.example
@@ -30,7 +30,6 @@ backupmanager:
     prefix: $hostname
     strictpurge: true
     nice_level: 10
-    method: tarball
   mysql:
     databases:
       - toto

--- a/pillar.example
+++ b/pillar.example
@@ -62,13 +62,11 @@ backupmanager:
       access_key: access
       secret_key: secret
   pipe:
-    0:
-      command: ssh host -c \"mysqldump -ufoo -pbar base\"
+    - command: ssh host -c \"mysqldump -ufoo -pbar base\"
       name: base
       filetype: sql
       compress: gzip
-    1:
-      command: ssh host -c \"mysqldump -ufoo -pbar base\"
+    - command: ssh host -c \"mysqldump -ufoo -pbar base\"
       name: base
       filetype: sql
       compress: gzip

--- a/pillar.example
+++ b/pillar.example
@@ -40,7 +40,6 @@ backupmanager:
     host:   localhost
     databases: 'paf pif'
   upload:
-    method: ssh
     destination: /tmp
     ssh:
       user: toto

--- a/pillar.example
+++ b/pillar.example
@@ -75,6 +75,5 @@ backupmanager:
   tarballinc:
       masterdatetype: weekly
       masterdatevalue: 1
-  commands:
-      pre_backup: /root/pre_backup.sh
-      post_backup: /root/post_backup.sh
+  pre_backup_command: /root/pre_backup.sh
+  post_backup_command: /root/post_backup.sh

--- a/pillar.example
+++ b/pillar.example
@@ -47,7 +47,12 @@ backupmanager:
       hosts:
         - toto.com
         - titi.org
-      gpg_recipient: POUF
+    sshgpg:
+      user: toor
+      key:  toor.key
+      hosts:
+        - tata.net
+      recipient: POUF
     ftp:
       secure:     false
       passive:    true


### PR DESCRIPTION
* Simplify setting of BM_ARCHIVE_METHOD and BM_UPLOAD_METHOD by inspecting defined keys in pillar (and fixes the issue raised in PR #1).
* Fix issue with ssh-gpg backup method
* Make use of defaults.yaml and move OS dependent data there. Both Ubuntu and Debian share these so this avoids having osfamilymap.yaml for now but it can be extended for other distributions if needs be.
* Add creation of the repository in install.sls. We had this state internally but it ought to be in the formula.

Not sure everything is correct but I could still run tarball, mysql and pgsql backup methods.